### PR TITLE
[Hotfix] Update to 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.s3ns3iw00'
-version '4.0.0'
+version '4.0.1'
 
 sourceCompatibility = 1.8
 targetCompatibility  = 1.8

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/SubArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/SubArgument.java
@@ -25,10 +25,12 @@ import java.util.LinkedList;
 /**
  * Represents a sub argument
  * Classes that extends this class can have arguments
+ *
+ * @param <T> the type of arguments that can contain this argument
  */
-public abstract class SubArgument extends Argument {
+public abstract class SubArgument<T extends Argument> extends Argument {
 
-    private final LinkedList<Argument> arguments = new LinkedList<>();
+    private final LinkedList<T> arguments = new LinkedList<>();
 
     /**
      * Constructs the argument with the default requirements
@@ -41,7 +43,14 @@ public abstract class SubArgument extends Argument {
         super(name, description, type);
     }
 
-    public LinkedList<Argument> getArguments() {
+    public LinkedList<T> getArguments() {
         return arguments;
     }
+
+    /**
+     * Adds an argument to the argument
+     *
+     * @param argument the argument
+     */
+    public abstract void addArgument(T argument);
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ConstantArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ConstantArgument.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
  *
  * @author S3nS3IW00
  */
-public class ConstantArgument extends SubArgument {
+public class ConstantArgument extends SubArgument<InputArgument> {
 
     public ConstantArgument(String name, String description) {
         super(name, description, SlashCommandOptionType.SUB_COMMAND);
@@ -57,7 +57,7 @@ public class ConstantArgument extends SubArgument {
      * @param argument the argument
      */
     public void addArgument(InputArgument argument) {
-        if (getArguments().size() > 0 && (getArguments().getLast() instanceof InputArgument) && ((InputArgument) getArguments().getLast()).isOptional()) {
+        if (getArguments().size() > 0 && (getArguments().getLast() != null) && getArguments().getLast().isOptional()) {
             throw new IllegalStateException("Cannot add argument after an optional argument!");
         }
 

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/GroupArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/GroupArgument.java
@@ -23,13 +23,14 @@ import me.s3ns3iw00.jcommands.argument.SubArgument;
 import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 /**
  * Represents an argument with {@code SUB_COMMAND_GROUP} type that only can contain {@link ConstantArgument}
  * This is for grouping {@code SUB_COMMAND} options because {@code SUB_COMMANDS} cannot be nested
  */
-public class GroupArgument extends SubArgument {
+public class GroupArgument extends SubArgument<ConstantArgument> {
 
     public GroupArgument(String name, String description) {
         super(name, description, SlashCommandOptionType.SUB_COMMAND_GROUP);
@@ -57,6 +58,15 @@ public class GroupArgument extends SubArgument {
      */
     public void addArgument(ConstantArgument argument) {
         getArguments().add(argument);
+    }
+
+    /**
+     * Adds a list of {@link ConstantArgument} to the argument
+     *
+     * @param arguments the arguments
+     */
+    public void addArgument(ConstantArgument... arguments) {
+        Arrays.stream(arguments).forEach(this::addArgument);
     }
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/ServerCommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/ServerCommandBuilder.java
@@ -19,13 +19,19 @@
 package me.s3ns3iw00.jcommands.builder;
 
 import me.s3ns3iw00.jcommands.Command;
-import me.s3ns3iw00.jcommands.listener.CommandActionListener;
 import me.s3ns3iw00.jcommands.argument.Argument;
+import me.s3ns3iw00.jcommands.limitation.type.CategoryLimitation;
+import me.s3ns3iw00.jcommands.limitation.type.ChannelLimitation;
+import me.s3ns3iw00.jcommands.limitation.type.RoleLimitation;
+import me.s3ns3iw00.jcommands.limitation.type.UserLimitation;
+import me.s3ns3iw00.jcommands.listener.CommandActionListener;
 import me.s3ns3iw00.jcommands.type.ServerCommand;
 import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.user.User;
+
+import java.util.Arrays;
 
 /**
  * Useful class that makes {@code ServerCommand} creations more comfortable
@@ -87,6 +93,46 @@ public class ServerCommandBuilder extends CommandBuilder {
      */
     public ServerCommandBuilder roles(boolean needAllRole, Role... roles) {
         command.setRoles(needAllRole, roles);
+        return this;
+    }
+
+    /**
+     * Calls {@link ServerCommand#addUserLimitation(UserLimitation)}
+     *
+     * @return this class
+     */
+    public ServerCommandBuilder userLimitations(UserLimitation... limitations) {
+        Arrays.stream(limitations).forEach(command::addUserLimitation);
+        return this;
+    }
+
+    /**
+     * Calls {@link ServerCommand#addChannelLimitation(ChannelLimitation)}
+     *
+     * @return this class
+     */
+    public ServerCommandBuilder channelLimitations(ChannelLimitation... limitations) {
+        Arrays.stream(limitations).forEach(command::addChannelLimitation);
+        return this;
+    }
+
+    /**
+     * Calls {@link ServerCommand#addCategoryLimitation(CategoryLimitation)}
+     *
+     * @return this class
+     */
+    public ServerCommandBuilder categoryLimitations(CategoryLimitation... limitations) {
+        Arrays.stream(limitations).forEach(command::addCategoryLimitation);
+        return this;
+    }
+
+    /**
+     * Calls {@link ServerCommand#addRoleLimitation(RoleLimitation)}
+     *
+     * @return this class
+     */
+    public ServerCommandBuilder roleLimitations(RoleLimitation... limitations) {
+        Arrays.stream(limitations).forEach(command::addRoleLimitation);
         return this;
     }
 

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
@@ -18,23 +18,15 @@
  */
 package me.s3ns3iw00.jcommands.limitation.type;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for categories
  */
 public interface CategoryLimitable {
 
-    List<CategoryLimitation> categoryLimitations = new ArrayList<>();
+    void addCategoryLimitation(CategoryLimitation limitation);
 
-    default void addCategoryLimitation(CategoryLimitation limitation) {
-        categoryLimitations.add(limitation);
-    }
-
-    default List<CategoryLimitation> getCategoryLimitations() {
-        return Collections.unmodifiableList(categoryLimitations);
-    }
+    Set<CategoryLimitation> getCategoryLimitations();
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
@@ -18,23 +18,15 @@
  */
 package me.s3ns3iw00.jcommands.limitation.type;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for channels
  */
 public interface ChannelLimitable {
 
-    List<ChannelLimitation> channelLimitations = new ArrayList<>();
+    void addChannelLimitation(ChannelLimitation limitation);
 
-    default void addChannelLimitation(ChannelLimitation limitation) {
-        channelLimitations.add(limitation);
-    }
-
-    default List<ChannelLimitation> getChannelLimitations() {
-        return Collections.unmodifiableList(channelLimitations);
-    }
+    Set<ChannelLimitation> getChannelLimitations();
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
@@ -18,23 +18,15 @@
  */
 package me.s3ns3iw00.jcommands.limitation.type;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for roles
  */
 public interface RoleLimitable {
 
-    List<RoleLimitation> roleLimitations = new ArrayList<>();
+    void addRoleLimitation(RoleLimitation limitation);
 
-    default void addRoleLimitation(RoleLimitation limitation) {
-        roleLimitations.add(limitation);
-    }
-
-    default List<RoleLimitation> getRoleLimitations() {
-        return Collections.unmodifiableList(roleLimitations);
-    }
+    Set<RoleLimitation> getRoleLimitations();
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
@@ -18,25 +18,15 @@
  */
 package me.s3ns3iw00.jcommands.limitation.type;
 
-import org.javacord.api.entity.user.User;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for users
  */
 public interface UserLimitable {
 
-    List<UserLimitation> userLimitations = new ArrayList<>();
+    void addUserLimitation(UserLimitation limitation);
 
-    default void addUserLimitation(UserLimitation limitation) {
-        userLimitations.add(limitation);
-    }
-
-    default List<UserLimitation> getUserLimitations() {
-        return Collections.unmodifiableList(userLimitations);
-    }
+    Set<UserLimitation> getUserLimitations();
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
@@ -25,9 +25,9 @@ import me.s3ns3iw00.jcommands.limitation.type.ChannelLimitation;
 import org.javacord.api.entity.channel.ChannelCategory;
 import org.javacord.api.entity.channel.TextChannel;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * An extended version of {@code PrivateCommand} that can be used also on servers and can be limited for channels and categories.
@@ -36,6 +36,9 @@ import java.util.List;
  */
 @Deprecated
 public class GlobalCommand extends PrivateCommand implements ChannelLimitable, CategoryLimitable {
+
+    private final Set<ChannelLimitation> channelLimitations = new HashSet<>();
+    private final Set<CategoryLimitation> categoryLimitations = new HashSet<>();
 
     public GlobalCommand(String name, String description) {
         super(name, description);
@@ -96,5 +99,25 @@ public class GlobalCommand extends PrivateCommand implements ChannelLimitable, C
     @Deprecated
     public boolean isAllowedChannels() {
         return false;
+    }
+
+    @Override
+    public void addCategoryLimitation(CategoryLimitation limitation) {
+        categoryLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<CategoryLimitation> getCategoryLimitations() {
+        return categoryLimitations;
+    }
+
+    @Override
+    public void addChannelLimitation(ChannelLimitation limitation) {
+        channelLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<ChannelLimitation> getChannelLimitations() {
+        return channelLimitations;
     }
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/type/PrivateCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/PrivateCommand.java
@@ -27,16 +27,21 @@ import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A {@code Command} that can be only used in private message and can be limited for users and roles.
- *
+ * <p>
  * Deprecated since the new command system doesn't support private commands.
  */
 @Deprecated
 public class PrivateCommand extends Command implements UserLimitable, RoleLimitable {
+
+    private final Set<UserLimitation> userLimitations = new HashSet<>();
+    private final Set<RoleLimitation> roleLimitations = new HashSet<>();
 
     public PrivateCommand(String name, String description) {
         super(name, description);
@@ -119,5 +124,25 @@ public class PrivateCommand extends Command implements UserLimitable, RoleLimita
     @Deprecated
     public boolean isAllowedRoles() {
         return false;
+    }
+
+    @Override
+    public void addRoleLimitation(RoleLimitation limitation) {
+        roleLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<RoleLimitation> getRoleLimitations() {
+        return roleLimitations;
+    }
+
+    @Override
+    public void addUserLimitation(UserLimitation limitation) {
+        userLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<UserLimitation> getUserLimitations() {
+        return userLimitations;
     }
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
@@ -25,15 +25,20 @@ import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.user.User;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A {@code Command} that only can be used on servers where the command has been registered.<br>
  * Can be limited for users, roles, channels and categories.
  */
 public class ServerCommand extends Command implements UserLimitable, RoleLimitable, ChannelLimitable, CategoryLimitable {
+
+    private final Set<UserLimitation> userLimitations = new HashSet<>();
+    private final Set<RoleLimitation> roleLimitations = new HashSet<>();
+    private final Set<ChannelLimitation> channelLimitations = new HashSet<>();
+    private final Set<CategoryLimitation> categoryLimitations = new HashSet<>();
 
     public ServerCommand(String name, String description) {
         super(name, description);
@@ -152,5 +157,45 @@ public class ServerCommand extends Command implements UserLimitable, RoleLimitab
     @Deprecated
     public boolean isAllowedUsers() {
         return false;
+    }
+
+    @Override
+    public void addCategoryLimitation(CategoryLimitation limitation) {
+        categoryLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<CategoryLimitation> getCategoryLimitations() {
+        return categoryLimitations;
+    }
+
+    @Override
+    public void addChannelLimitation(ChannelLimitation limitation) {
+        channelLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<ChannelLimitation> getChannelLimitations() {
+        return channelLimitations;
+    }
+
+    @Override
+    public void addRoleLimitation(RoleLimitation limitation) {
+        roleLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<RoleLimitation> getRoleLimitations() {
+        return roleLimitations;
+    }
+
+    @Override
+    public void addUserLimitation(UserLimitation limitation) {
+        userLimitations.add(limitation);
+    }
+
+    @Override
+    public Set<UserLimitation> getUserLimitations() {
+        return userLimitations;
     }
 }


### PR DESCRIPTION
- Fixed limitations
> Limitations were stored in they own interface. Since interfaces can contains only `public static final` fields, limitations were applied for every command
- Added new limitation to builder
- Added generic type to SubArgument to be able to add an abstract method that need to have a generic parameter that can be anything that extends Argument class