### PR TITLE
Update to 4.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JCommands [![](https://img.shields.io/badge/Version-4.0.1-blue)](https://github.com/S3nS3IW00/JCommands) [![](https://img.shields.io/badge/Javadoc-Latest-green)](https://s3ns3iw00.github.io/JCommands/javadoc/)
+# JCommands [![](https://img.shields.io/badge/Version-4.0.2-blue)](https://github.com/S3nS3IW00/JCommands) [![](https://img.shields.io/badge/Javadoc-Latest-green)](https://s3ns3iw00.github.io/JCommands/javadoc/)
 
 With this Javacord extension you can create Slash commands within 1 minute with built-in validating, converting and
 extended permission checking for channels and categories. There are so many useful pre-written argument types that can

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.s3ns3iw00'
-version '4.0.1'
+version '4.0.2'
 
 sourceCompatibility = 1.8
 targetCompatibility  = 1.8

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -20,17 +20,19 @@ package me.s3ns3iw00.jcommands;
 
 import me.s3ns3iw00.jcommands.argument.Argument;
 import me.s3ns3iw00.jcommands.argument.ArgumentResult;
+import me.s3ns3iw00.jcommands.argument.InputArgument;
 import me.s3ns3iw00.jcommands.argument.SubArgument;
 import me.s3ns3iw00.jcommands.argument.converter.ArgumentResultConverter;
 import me.s3ns3iw00.jcommands.argument.converter.type.URLConverter;
-import me.s3ns3iw00.jcommands.argument.type.ComboArgument;
-import me.s3ns3iw00.jcommands.argument.type.ValueArgument;
 import me.s3ns3iw00.jcommands.builder.CommandBuilder;
 import me.s3ns3iw00.jcommands.builder.GlobalCommandBuilder;
 import me.s3ns3iw00.jcommands.builder.PrivateCommandBuilder;
 import me.s3ns3iw00.jcommands.builder.ServerCommandBuilder;
 import me.s3ns3iw00.jcommands.limitation.Limitation;
-import me.s3ns3iw00.jcommands.limitation.type.*;
+import me.s3ns3iw00.jcommands.limitation.type.CategoryLimitable;
+import me.s3ns3iw00.jcommands.limitation.type.ChannelLimitable;
+import me.s3ns3iw00.jcommands.limitation.type.RoleLimitable;
+import me.s3ns3iw00.jcommands.limitation.type.UserLimitable;
 import me.s3ns3iw00.jcommands.listener.CommandErrorListener;
 import me.s3ns3iw00.jcommands.type.GlobalCommand;
 import me.s3ns3iw00.jcommands.type.PrivateCommand;
@@ -186,19 +188,16 @@ public class CommandHandler {
                     } else {
                         return Optional.empty();
                     }
-                } else if (argument instanceof ComboArgument) {
-                    // Simply adjust the argument's value to the option's value and add it to the list
-                    ((ComboArgument) argument).choose(value);
-                    results.add(new ArgumentResult(argument));
-                } else if (argument instanceof ValueArgument) {
-                    /* Check that the option's value is valid for the argument
-                       If it is valid then the validator adjust the argument's value to that value, and it will be added to the list,
+                } else if (argument instanceof InputArgument) {
+                    /* Adjusts the value to the argument and checks that the value is null
+                       If it is not then it will be added to the list,
                             otherwise return an empty optional to tell the caller that one of the argument is not valid
                      */
-                    ValueArgument va = (ValueArgument) argument;
+                    InputArgument ia = (InputArgument) argument;
+                    ia.input(value);
 
-                    if (va.isValid(value)) {
-                        results.add(new ArgumentResult(va));
+                    if (ia.getValue() != null) {
+                        results.add(new ArgumentResult(ia));
                     } else {
                         return Optional.empty();
                     }
@@ -273,8 +272,8 @@ public class CommandHandler {
      * Applies default Discord permissions on command
      *
      * @param command the command
-     * @param id the slash command's id
-     * @param server the server
+     * @param id      the slash command's id
+     * @param server  the server
      */
     private static void applyPermissions(Command command, long id, Server server) {
         List<SlashCommandPermissions> permissions = new ArrayList<>();

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
@@ -18,6 +18,9 @@
  */
 package me.s3ns3iw00.jcommands.argument;
 
+import org.javacord.api.entity.channel.TextChannel;
+import org.javacord.api.entity.permission.Role;
+import org.javacord.api.entity.user.User;
 import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
@@ -27,6 +30,8 @@ import org.javacord.api.interaction.SlashCommandOptionType;
  */
 public abstract class InputArgument extends Argument {
 
+    private Object input;
+    private final Class<?> resultType;
     private boolean optional = false;
 
     /**
@@ -38,6 +43,42 @@ public abstract class InputArgument extends Argument {
      */
     public InputArgument(String name, String description, SlashCommandOptionType type) {
         super(name, description, type);
+
+        Class<?> resultType = Object.class;
+        switch (type) {
+            case STRING:
+                resultType = String.class;
+                break;
+            case INTEGER:
+                resultType = Integer.class;
+                break;
+            case BOOLEAN:
+                resultType = Boolean.class;
+                break;
+            case CHANNEL:
+                resultType = TextChannel.class;
+                break;
+            case ROLE:
+                resultType = Role.class;
+                break;
+            case USER:
+                resultType = User.class;
+                break;
+        }
+        this.resultType = resultType;
+    }
+
+    /**
+     * Runs the default constructor and specifies the result type of the value, that the input will be converted to
+     *
+     * @param name        the argument's name
+     * @param description the argument's description
+     * @param type        the type of the value
+     * @param resultType  the type of the converted value
+     */
+    public InputArgument(String name, String description, SlashCommandOptionType type, Class<?> resultType) {
+        super(name, description, type);
+        this.resultType = resultType;
     }
 
     @Override
@@ -55,6 +96,25 @@ public abstract class InputArgument extends Argument {
      */
     public void setOptional() {
         optional = true;
+    }
+
+    /**
+     * Sets the input
+     *
+     * @param input the input
+     */
+    public void input(Object input) {
+        this.input = input;
+    }
+
+    @Override
+    public Object getValue() {
+        return input;
+    }
+
+    @Override
+    public Class<?> getResultType() {
+        return resultType;
     }
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ChannelArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ChannelArgument.java
@@ -18,6 +18,7 @@
  */
 package me.s3ns3iw00.jcommands.argument.type;
 
+import me.s3ns3iw00.jcommands.argument.InputArgument;
 import org.javacord.api.entity.channel.ServerChannel;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
@@ -26,7 +27,7 @@ import org.javacord.api.interaction.SlashCommandOptionType;
  *
  * @author S3nS3IW00
  */
-public class ChannelArgument extends ValueArgument {
+public class ChannelArgument extends InputArgument {
 
     public ChannelArgument(String name, String description) {
         super(name, description, SlashCommandOptionType.CHANNEL, ServerChannel.class);

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
@@ -27,22 +27,19 @@ import java.util.LinkedList;
 
 /**
  * Represents an argument that has multiple choices, and they are the only valid values for the user to pick
- *
  * The values are key value pairs
  * The key is {@code String} and the value can be {@code String} or {@code Integer}
  */
 public class ComboArgument extends InputArgument {
-
-    private Object value;
 
     private final LinkedList<SlashCommandOptionChoice> choices = new LinkedList<>();
 
     /**
      * Constructs the argument with the default requirements
      *
-     * @param name the argument's name
+     * @param name        the argument's name
      * @param description the argument's description
-     * @param type the type of the input value, can be {@code STRING} or {@code INTEGER}
+     * @param type        the type of the input value, can be {@code STRING} or {@code INTEGER}
      */
     public ComboArgument(String name, String description, SlashCommandOptionType type) {
         super(name, description, type);
@@ -55,7 +52,7 @@ public class ComboArgument extends InputArgument {
     /**
      * Adds a choice
      *
-     * @param key is the name of the argument
+     * @param key   is the name of the argument
      * @param value is the value of the argument as {@code String}
      */
     public void addChoice(String key, String value) {
@@ -69,7 +66,7 @@ public class ComboArgument extends InputArgument {
     /**
      * Adds a choice
      *
-     * @param key the name of the argument
+     * @param key   the name of the argument
      * @param value the value of the argument as {@code Integer}
      */
     public void addChoice(String key, int value) {
@@ -80,21 +77,12 @@ public class ComboArgument extends InputArgument {
         choices.add(SlashCommandOptionChoice.create(key, value));
     }
 
-    /**
-     * Sets the chosen value
-     *
-     * @param value the chosen value
-     */
-    public void choose(Object value) {
-        this.value = value;
-    }
-
     @Override
     public Object getValue() {
         if (getType() == SlashCommandOptionType.STRING) {
-            return value.toString();
+            return super.getValue().toString();
         }
-        return value;
+        return super.getValue();
     }
 
     @Override

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/MentionArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/MentionArgument.java
@@ -18,6 +18,7 @@
  */
 package me.s3ns3iw00.jcommands.argument.type;
 
+import me.s3ns3iw00.jcommands.argument.InputArgument;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
@@ -26,7 +27,7 @@ import org.javacord.api.interaction.SlashCommandOptionType;
  *
  * @author S3nS3IW00
  */
-public class MentionArgument extends ValueArgument {
+public class MentionArgument extends InputArgument {
 
     public MentionArgument(String name, String description) {
         super(name, description, SlashCommandOptionType.USER, User.class);

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/NumberArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/NumberArgument.java
@@ -34,16 +34,29 @@ public class NumberArgument extends ValueArgument {
         super(name, description, SlashCommandOptionType.INTEGER, Integer.class);
     }
 
+    /**
+     * Sets a range for the number
+     * NOTE: this is an inclusive range
+     *
+     * @param min the minimum
+     * @param max the maximum
+     */
     public void setRange(int min, int max) {
         this.min = min;
         this.max = max;
     }
 
+    /**
+     * Extends the {@link ValueArgument#isValid(Object)} method with range checking
+     *
+     * @param value the value
+     * @return is the value in the range or not
+     */
     @Override
-    public boolean isValid(Object input) {
-        if (super.isValid(input)) {
+    public boolean isValid(Object value) {
+        if (super.isValid(value)) {
             try {
-                return (int) input >= min && (int) input <= max;
+                return (int) value >= min && (int) value <= max;
             } catch (NumberFormatException e) {
                 return false;
             }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/RoleArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/RoleArgument.java
@@ -18,13 +18,14 @@
  */
 package me.s3ns3iw00.jcommands.argument.type;
 
+import me.s3ns3iw00.jcommands.argument.InputArgument;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
 /**
  * An argument that only accepts role as input and returns a {@link Role}
  */
-public class RoleArgument extends ValueArgument {
+public class RoleArgument extends InputArgument {
 
     public RoleArgument(String name, String description) {
         super(name, description, SlashCommandOptionType.ROLE, Role.class);

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/StringArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/StringArgument.java
@@ -34,12 +34,24 @@ public class StringArgument extends ValueArgument {
         super(name, description, SlashCommandOptionType.STRING, String.class);
     }
 
+    /**
+     * Sets the maximum length for the string
+     * NOTE: this is an inclusive range
+     *
+     * @param max the maximum
+     */
     public void setMaxLength(int max) {
         this.max = max;
     }
 
+    /**
+     * Extends the {@link ValueArgument#isValid(Object)} method with length checking
+     *
+     * @param value the value
+     * @return is the value's length less or equals than the maximum
+     */
     @Override
-    public boolean isValid(Object input) {
-        return super.isValid(input) && input.toString().length() <= max;
+    public boolean isValid(Object value) {
+        return super.isValid(value) && value.toString().length() <= max;
     }
 }


### PR DESCRIPTION
- [`InputArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java) and [`ComboArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java) has been reorganized
  - [`CommandHandler`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java) now uses [`InputArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java) instead of [`ValueArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/type/ValueArgument.java) to validate arguments that acceps various type of input, but [`InputArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java) does not have validation system, it is still in [`ValueArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/type/ValueArgument.java)
  - [`ComboArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java) has been removed from the validation process, it is now validated fully as an [`InputArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java), hence [`ComboArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java)'s api has been changed to process validation trough [`InputArgument`](https://github.com/S3nS3IW00/JCommands/blob/master/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java)'s API