### PR TITLE
Update to v5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JCommands [![](https://img.shields.io/badge/Version-4.2.0-blue)](https://github.com/S3nS3IW00/JCommands) [![](https://img.shields.io/badge/Javadoc-Latest-green)](https://s3ns3iw00.github.io/JCommands/javadoc/) [![](https://img.shields.io/badge/Javacord-3.4.0-red)](https://github.com/Javacord/Javacord)
+# JCommands [![](https://img.shields.io/badge/Version-5.0.0-blue)](https://github.com/S3nS3IW00/JCommands) [![](https://img.shields.io/badge/Javadoc-Latest-green)](https://s3ns3iw00.github.io/JCommands/javadoc/) [![](https://img.shields.io/badge/Javacord-3.7.0-red)](https://github.com/Javacord/Javacord)
 
 With this Javacord extension you can create Slash commands within 1 minute with built-in validating, converting,
 concatenating, argument autocompleting and extended permission checking for channels and categories. There are so many
@@ -8,13 +8,13 @@ useful pre-written argument types that can be used while creating a command.
 
 This command is created just with about 50 lines of code including the response and error handling. It has a validated
 argument with regex, an argument that has two different values that the user can choose from, a number argument that has
-a range validation, a normal user mention argument, a normal channel mention argument and an optional URL argument that
-is a text input with regex validation. In the response the first argument is separated with regex groups into two
+a range validation, a normal user mention argument, a normal channel mention argument and an optional attachment argument 
+with size and extension validation. In the response the first argument is separated with regex groups into two
 different value, and the response based on every argument's value.
 
 ![Example](https://imgur.com/swqZYXH.png)
 
-> You can find a full code [here](https://github.com/S3nS3IW00/JCommands/blob/master/src/test/java/me/s3ns3iw00/jcommands/TestMain.java) that runs a bot with the example command above.
+> You can find the full code [here](https://github.com/S3nS3IW00/JCommands/blob/master/src/test/java/me/s3ns3iw00/jcommands/TestMain.java) that runs a bot with the example command above.
 
 ## Wiki
 
@@ -46,5 +46,5 @@ bots with it.
 ## Contact
 
 If you found a bug, or you just want a new feature in the next version, don't hesitate to report it on
-the [issues](https://github.com/S3nS3IW00/JCommands/issues) page. You can contact me through
+the [issues](https://github.com/S3nS3IW00/JCommands/issues) page or feel free to open a pull request. You can contact me through
 discord: [🆂🅴🅽🆂🅴🆈#0054](https://discord.com/users/249674530077802496)

--- a/build.gradle
+++ b/build.gradle
@@ -11,5 +11,5 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    implementation 'org.javacord:javacord:3.4.0'
+    implementation 'org.javacord:javacord:3.7.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.s3ns3iw00'
-version '4.2.0'
+version '5.0.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/me/s3ns3iw00/jcommands/Command.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/Command.java
@@ -19,7 +19,7 @@
 package me.s3ns3iw00.jcommands;
 
 import me.s3ns3iw00.jcommands.argument.Argument;
-import me.s3ns3iw00.jcommands.argument.InputArgument;
+import me.s3ns3iw00.jcommands.argument.ability.Optionality;
 import me.s3ns3iw00.jcommands.argument.concatenation.Concatenator;
 import me.s3ns3iw00.jcommands.event.listener.ArgumentMismatchEventListener;
 import me.s3ns3iw00.jcommands.event.listener.CommandActionEventListener;
@@ -80,9 +80,9 @@ public class Command {
      */
     public void addArgument(Argument argument) {
         if (arguments.size() > 0 &&
-                (arguments.getLast() instanceof InputArgument) &&
-                ((InputArgument) arguments.getLast()).isOptional() &&
-                !((InputArgument) argument).isOptional()) {
+                (arguments.getLast() instanceof Optionality) &&
+                ((Optionality) arguments.getLast()).isOptional() &&
+                !((Optionality) argument).isOptional()) {
             throw new IllegalStateException("Cannot add non-optional argument after an optional argument!");
         }
 

--- a/src/main/java/me/s3ns3iw00/jcommands/Command.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/Command.java
@@ -23,6 +23,7 @@ import me.s3ns3iw00.jcommands.argument.InputArgument;
 import me.s3ns3iw00.jcommands.argument.concatenation.Concatenator;
 import me.s3ns3iw00.jcommands.event.listener.ArgumentMismatchEventListener;
 import me.s3ns3iw00.jcommands.event.listener.CommandActionEventListener;
+import org.javacord.api.entity.permission.PermissionType;
 
 import java.util.*;
 
@@ -39,6 +40,10 @@ public class Command {
     private final String name, description;
     private final LinkedList<Argument> arguments = new LinkedList<>();
     private final Map<Concatenator, LinkedList<Argument>> concatenators = new LinkedHashMap<>();
+
+    private final Set<PermissionType> defaultPermissions = new HashSet<>();
+
+    private boolean onlyForAdministrators = false;
 
     private CommandActionEventListener actionListener;
     private ArgumentMismatchEventListener argumentMismatchListener;
@@ -108,6 +113,23 @@ public class Command {
     }
 
     /**
+     * Adds permissions that will be applied on the command
+     * Users will need these permissions in the specific channel to use the command
+     *
+     * @param permissionTypes a list of {@link PermissionType}
+     */
+    public void addPermissions(PermissionType... permissionTypes) {
+        defaultPermissions.addAll(Arrays.asList(permissionTypes));
+    }
+
+    /**
+     * Sets the command available only for administrators by default
+     */
+    public void setOnlyForAdministrators() {
+        this.onlyForAdministrators = true;
+    }
+
+    /**
      * Sets the action listener
      *
      * @param listener the listener
@@ -142,6 +164,14 @@ public class Command {
      */
     public Map<Concatenator, LinkedList<Argument>> getConcatenators() {
         return concatenators;
+    }
+
+    public Set<PermissionType> getDefaultPermissions() {
+        return defaultPermissions;
+    }
+
+    public boolean isOnlyForAdministrators() {
+        return onlyForAdministrators;
     }
 
     /**

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -223,7 +223,7 @@ public class CommandHandler {
      * - Assembles a list with the result of every argument
      *
      * @param arguments the list of arguments need to be processed
-     * @param options   the list of {@link SlashCommandInteractionOption} corresponding to {@code arguments} parameter
+     * @param options   the list of {@link SlashCommandInteractionOption} corresponding to {@param arguments} parameter
      * @return an {@link Optional} that is empty when one option found that is not valid for the argument during the validating process,
      * otherwise it contains a {@link LinkedHashMap} with {@link Argument}s and their {@link ArgumentResult} in it that converts values to the final result
      */
@@ -577,7 +577,7 @@ public class CommandHandler {
      * Gets the registered converter by the type
      *
      * @param clazz the class of the type
-     * @return an {@code Optional} that is empty when there is no registered converter for the given type otherwise with value of the converter
+     * @return an {@link Optional} that is empty when there is no registered converter for the given type otherwise with value of the converter
      */
     public static Optional<ArgumentResultConverter> getArgumentConverter(Class<?> clazz) {
         if (converters.containsKey(clazz)) {

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -313,6 +313,9 @@ public class CommandHandler {
             case BOOLEAN:
                 value = option.getBooleanValue().orElse(null);
                 break;
+            case ATTACHMENT:
+                value = option.getAttachmentValue().orElse(null);
+                break;
             default:
                 value = null;
         }

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -23,6 +23,7 @@ import me.s3ns3iw00.jcommands.argument.ArgumentResult;
 import me.s3ns3iw00.jcommands.argument.InputArgument;
 import me.s3ns3iw00.jcommands.argument.SubArgument;
 import me.s3ns3iw00.jcommands.argument.ability.Autocompletable;
+import me.s3ns3iw00.jcommands.argument.ability.Optionality;
 import me.s3ns3iw00.jcommands.argument.autocomplete.AutocompleteState;
 import me.s3ns3iw00.jcommands.argument.concatenation.Concatenator;
 import me.s3ns3iw00.jcommands.argument.converter.ArgumentResultConverter;
@@ -137,15 +138,15 @@ public class CommandHandler {
                        Except the optional arguments that haven't been specified
                      */
                     List<Argument> concatenatedArguments = command.getConcatenators().get(concatenator).stream()
-                            .filter(arg -> !(arg instanceof InputArgument) ||
-                                    !((InputArgument) arg).isOptional() ||
-                                    (((InputArgument) arg).isOptional() &&
+                            .filter(arg -> !(arg instanceof Optionality) ||
+                                    !((Optionality) arg).isOptional() ||
+                                    (((Optionality) arg).isOptional() &&
                                             resultOptional.get().containsKey(arg)))
                             .collect(Collectors.toCollection(LinkedList::new));
 
                     // Checks whether an argument's result is exist (so it has a value) or it is optional (so it does not need to have a value)
                     Predicate<Argument> argumentExistenceChecker = arg -> resultOptional.get().containsKey(arg) ||
-                            (arg instanceof InputArgument) && ((InputArgument) arg).isOptional();
+                            (arg instanceof Optionality) && ((Optionality) arg).isOptional();
                     // Concatenating if the result contains all the arguments in the concatenator or if the argument is optional
                     if (concatenatedArguments.stream().allMatch(argumentExistenceChecker)) {
                         /* Replaces the results with the already concatenated ones in the list that belongs to arguments that have been concatenated before

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -456,44 +456,6 @@ public class CommandHandler {
     }
 
     /**
-     * Applies default Discord permissions on command
-     *
-     * @param command the command
-     * @param id      the slash command's id
-     * @param server  the server
-     * @deprecated because this functionality got removed
-     */
-    @Deprecated
-    private static void applyPermissions(Command command, long id, Server server) {
-        /*List<ApplicationCommandPermissions> permissions = new ArrayList<>();
-        if (command instanceof UserLimitable) {
-            UserLimitable userLimitable = (UserLimitable) command;
-            permissions.addAll(userLimitable.getUserLimitations().stream()
-                    .filter(user -> user.getServer().getId() == server.getId())
-                    .map(user -> ApplicationCommandPermissions.create(user.getEntity().getId(),
-                            ApplicationCommandPermissionType.USER,
-                            user.isPermit()))
-                    .collect(Collectors.toList()));
-        }
-        if (command instanceof RoleLimitable) {
-            RoleLimitable roleLimitable = (RoleLimitable) command;
-            permissions.addAll(roleLimitable.getRoleLimitations().stream()
-                    .filter(user -> user.getServer().getId() == server.getId())
-                    .map(role -> ApplicationCommandPermissions.create(role.getEntity().getId(),
-                            ApplicationCommandPermissionType.ROLE,
-                            role.isPermit()))
-                    .collect(Collectors.toList()));
-        }
-
-        if (permissions.size() > 0) {
-            new ApplicationCommandPermissionsUpdater(server)
-                    .setPermissions(permissions)
-                    .update(id)
-                    .join();
-        }*/
-    }
-
-    /**
      * Calls the {@link CommandHandler#registerCommand(ServerCommand, Server...)} method with the command contained by the {@link ServerCommandBuilder} class
      *
      * @param builder the builder

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandHandler.java
@@ -31,8 +31,12 @@ import me.s3ns3iw00.jcommands.argument.converter.type.URLConverter;
 import me.s3ns3iw00.jcommands.argument.type.ComboArgument;
 import me.s3ns3iw00.jcommands.argument.util.Choice;
 import me.s3ns3iw00.jcommands.builder.CommandBuilder;
+import me.s3ns3iw00.jcommands.builder.type.GlobalCommandBuilder;
+import me.s3ns3iw00.jcommands.builder.type.ServerCommandBuilder;
 import me.s3ns3iw00.jcommands.event.type.ArgumentMismatchEvent;
 import me.s3ns3iw00.jcommands.event.type.CommandActionEvent;
+import me.s3ns3iw00.jcommands.type.GlobalCommand;
+import me.s3ns3iw00.jcommands.type.ServerCommand;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.permission.PermissionType;
@@ -363,7 +367,7 @@ public class CommandHandler {
      * @param command the command
      * @param servers the list of the servers where the command will be registered
      */
-    public static void registerCommand(Command command, Server... servers) {
+    public static void registerCommand(ServerCommand command, Server... servers) {
         commands.add(command);
 
         for (Server server : servers) {
@@ -386,12 +390,12 @@ public class CommandHandler {
 
     /**
      * Registers command globally
-     * That means the command will be available in all the servers where the bot on, and also in private
+     * That means the command will be available in all the servers where the bot on, and also can be available in dms
      * Sets up permissions with discord's default permission system
      *
      * @param command the command to register
      */
-    public static void registerCommand(Command command) {
+    public static void registerCommand(GlobalCommand command) {
         commands.add(command);
 
         /* Check if the command with the name is already registered
@@ -426,6 +430,10 @@ public class CommandHandler {
             slashCommandUpdater.setDefaultEnabledForEveryone();
         }
 
+        if (command instanceof GlobalCommand) {
+            slashCommandUpdater.setEnabledInDms(((GlobalCommand) command).isEnabledInDMs());
+        }
+
         return slashCommandUpdater;
     }
 
@@ -447,6 +455,10 @@ public class CommandHandler {
             slashCommandBuilder.setDefaultDisabled();
         } else {
             slashCommandBuilder.setDefaultEnabledForEveryone();
+        }
+
+        if (command instanceof GlobalCommand) {
+            slashCommandBuilder.setEnabledInDms(((GlobalCommand) command).isEnabledInDMs());
         }
 
         return slashCommandBuilder;
@@ -491,22 +503,22 @@ public class CommandHandler {
     }
 
     /**
-     * Calls the {@link CommandHandler#registerCommand(Command, Server...)} method with the command contained by the {@code CommandBuilder} class
+     * Calls the {@link CommandHandler#registerCommand(ServerCommand, Server...)} method with the command contained by the {@link ServerCommandBuilder} class
      *
      * @param builder the builder
      * @param servers the list of the servers where the command will be registered
      */
-    public static void registerCommand(CommandBuilder<?> builder, Server... servers) {
-        registerCommand(builder.getCommand(), servers);
+    public static void registerCommand(ServerCommandBuilder builder, Server... servers) {
+        registerCommand((ServerCommand) builder.getCommand(), servers);
     }
 
     /**
-     * Calls the {@link CommandHandler#registerCommand(Command)} method with the command contained by the {@code CommandBuilder} class
+     * Calls the {@link CommandHandler#registerCommand(GlobalCommand)} method with the command contained by the {@link GlobalCommandBuilder} class
      *
      * @param builder the builder
      */
-    public static void registerCommand(CommandBuilder<?> builder) {
-        registerCommand(builder.getCommand());
+    public static void registerCommand(GlobalCommandBuilder builder) {
+        registerCommand((GlobalCommand) builder.getCommand());
     }
 
     /**

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
@@ -61,7 +61,7 @@ public class CommandResponder {
      *
      * @return the response updater
      */
-    public CompletableFuture<InteractionOriginalResponseUpdater> respondLater(boolean ephemeral) {
+    public CompletableFuture<InteractionOriginalResponseUpdater> respondLaterEphemeral() {
         return interaction.respondLater(true);
     }
 

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
@@ -18,11 +18,13 @@
  */
 package me.s3ns3iw00.jcommands;
 
+import org.javacord.api.entity.message.component.HighLevelComponent;
 import org.javacord.api.interaction.SlashCommandInteraction;
 import org.javacord.api.interaction.callback.InteractionFollowupMessageBuilder;
 import org.javacord.api.interaction.callback.InteractionImmediateResponseBuilder;
 import org.javacord.api.interaction.callback.InteractionOriginalResponseUpdater;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -68,6 +70,24 @@ public class CommandResponder {
      */
     public InteractionFollowupMessageBuilder followUp() {
         return interaction.createFollowupMessageBuilder();
+    }
+
+    /**
+     * Creates a responder to respond with a modal to the command
+     *
+     * @return the {@link CompletableFuture<Void>} that completes when the modal is opened
+     */
+    public CompletableFuture<Void> respondWithModal(String customId, String title, HighLevelComponent... highLevelComponents) {
+        return interaction.respondWithModal(customId, title, highLevelComponents);
+    }
+
+    /**
+     * Creates a responder to respond with a modal to the command
+     *
+     * @return the {@link CompletableFuture<Void>} that completes when the modal is opened
+     */
+    public CompletableFuture<Void> respondWithModal(String customId, String title, List<HighLevelComponent> highLevelComponents) {
+        return interaction.respondWithModal(customId, title, highLevelComponents);
     }
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/CommandResponder.java
@@ -55,6 +55,17 @@ public class CommandResponder {
     }
 
     /**
+     * Creates an ephemeral updater that listens for the response
+     * In this case a waiting message can be sent to the user
+     * NOTE: Late responses need to be sent within 15 minutes, otherwise Discord drops it
+     *
+     * @return the response updater
+     */
+    public CompletableFuture<InteractionOriginalResponseUpdater> respondLater(boolean ephemeral) {
+        return interaction.respondLater(true);
+    }
+
+    /**
      * Creates a responder to respond immediately to the command
      *
      * @return the immediate responder builder

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/ArgumentResult.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/ArgumentResult.java
@@ -19,6 +19,7 @@
 package me.s3ns3iw00.jcommands.argument;
 
 import me.s3ns3iw00.jcommands.CommandHandler;
+import me.s3ns3iw00.jcommands.argument.ability.Optionality;
 import me.s3ns3iw00.jcommands.argument.converter.ArgumentResultConverter;
 
 import java.util.Optional;
@@ -50,16 +51,23 @@ public class ArgumentResult {
      * @param argument the argument
      */
     public ArgumentResult(Argument argument) {
-        this(argument.getResultType(), argument.getValue());
+        this.clazz = argument.getResultType();
+
+        if (argument instanceof Optionality && ((Optionality) argument).isOptional()) {
+            this.value = ((Optionality) argument).getOptionalValue();
+        } else {
+            this.value = argument.getValue();
+        }
     }
 
     /**
      * Converts the value
      *
+     * @param value the value of the argument
      * @return the result of the conversion
      * @throws NullPointerException if converter haven't specified for this type of conversion
      */
-    private Object process() {
+    private Object convert(Object value) {
         if (clazz.isAssignableFrom(value.getClass())) {
             return value;
         } else {
@@ -101,7 +109,11 @@ public class ArgumentResult {
      */
     @SuppressWarnings("unchecked")
     public <T> T get() {
-        return (T) clazz.cast(process());
+        if (value instanceof Optional) {
+            return ((Optional<?>) value).map(o -> (T) Optional.of(clazz.cast(convert(o)))).orElseGet(() -> (T) Optional.empty());
+        }
+
+        return (T) clazz.cast(convert(value));
     }
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
@@ -31,6 +31,7 @@ import org.javacord.api.interaction.SlashCommandOptionType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents argument that can have multiple value depends on the user input and the restrictions of the argument
@@ -130,6 +131,11 @@ public abstract class InputArgument extends Argument implements Optionality, Aut
     @Override
     public Object getValue() {
         return input;
+    }
+
+    @Override
+    public Optional<?> getOptionalValue() {
+        return Optional.ofNullable(input);
     }
 
     @Override

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
@@ -106,10 +106,6 @@ public abstract class InputArgument extends Argument implements Optionality, Aut
         return optional;
     }
 
-    /**
-     * Sets the argument optional
-     * Only the last argument of the options can be set as optional
-     */
     public void setOptional() {
         optional = true;
     }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/InputArgument.java
@@ -21,6 +21,7 @@ package me.s3ns3iw00.jcommands.argument;
 import me.s3ns3iw00.jcommands.argument.ability.Autocompletable;
 import me.s3ns3iw00.jcommands.argument.ability.Optionality;
 import me.s3ns3iw00.jcommands.argument.autocomplete.Autocomplete;
+import org.javacord.api.entity.Attachment;
 import org.javacord.api.entity.channel.TextChannel;
 import org.javacord.api.entity.permission.Role;
 import org.javacord.api.entity.user.User;
@@ -72,6 +73,9 @@ public abstract class InputArgument extends Argument implements Optionality, Aut
                 break;
             case USER:
                 resultType = User.class;
+                break;
+            case ATTACHMENT:
+                resultType = Attachment.class;
                 break;
         }
         this.resultType = resultType;

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/ability/Optionality.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/ability/Optionality.java
@@ -18,6 +18,8 @@
  */
 package me.s3ns3iw00.jcommands.argument.ability;
 
+import java.util.Optional;
+
 /**
  * Identifies whether an argument can be optional or not
  */
@@ -30,5 +32,12 @@ public interface Optionality {
      * Only the last argument of the options can be set as optional
      */
     void setOptional();
+
+    /**
+     * Gets the value of the argument as optional
+     *
+     * @return the optional value
+     */
+    Optional<?> getOptionalValue();
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/ability/Optionality.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/ability/Optionality.java
@@ -25,4 +25,10 @@ public interface Optionality {
 
     boolean isOptional();
 
+    /**
+     * Sets the argument optional
+     * Only the last argument of the options can be set as optional
+     */
+    void setOptional();
+
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/AutocompleteState.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/AutocompleteState.java
@@ -37,10 +37,10 @@ public class AutocompleteState {
     private final User sender;
 
     private final Argument currentArgument;
-    private final Object currentValue;
-    private final Map<Argument, Object> argumentValues;
+    private final Optional<?> currentValue;
+    private final Map<Argument, Optional<?>> argumentValues;
 
-    public AutocompleteState(Command command, TextChannel channel, User sender, Argument currentArgument, Object currentValue, Map<Argument, Object> argumentValues) {
+    public AutocompleteState(Command command, TextChannel channel, User sender, Argument currentArgument, Optional<?> currentValue, Map<Argument, Optional<?>> argumentValues) {
         this.command = command;
         this.channel = channel;
         this.sender = sender;
@@ -65,11 +65,11 @@ public class AutocompleteState {
         return currentArgument;
     }
 
-    public Object getCurrentValue() {
+    public Optional<?> getCurrentValue() {
         return currentValue;
     }
 
-    public Map<Argument, Object> getArgumentValues() {
+    public Map<Argument, Optional<?>> getArgumentValues() {
         return argumentValues;
     }
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/type/SearchAutocomplete.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/type/SearchAutocomplete.java
@@ -114,16 +114,16 @@ public class SearchAutocomplete extends Autocomplete {
 
     @Override
     public List<Choice> getResult(AutocompleteState state) {
-        if (state.getCurrentValue().toString().length() < minCharToSearch) return null;
+        if (!state.getCurrentValue().isPresent() && state.getCurrentValue().toString().length() < minCharToSearch) return null;
 
         Stream<Choice> choices = dataSource.stream()
                 .filter(data -> {
                     /* If the datasource's type is String and the data in the datasource and the argument's value is also String
                        Filters the datasource by the type of search and the input
                      */
-                    if (dataType == SlashCommandOptionType.STRING && data instanceof String && state.getCurrentValue() instanceof String) {
+                    if (dataType == SlashCommandOptionType.STRING && data instanceof String && state.getCurrentValue().get() instanceof String) {
                         String strData = (String) data;
-                        String strValue = (String) state.getCurrentValue();
+                        String strValue = (String) state.getCurrentValue().get();
 
                         if (ignoreCase) {
                             strData = strData.toLowerCase();
@@ -140,9 +140,9 @@ public class SearchAutocomplete extends Autocomplete {
                     /* If the datasource's type is Long and the data in the datasource is Number and the argument's value is also Long
                        Filters the datasource by the type of search and the input
                      */
-                    } else if (dataType == SlashCommandOptionType.LONG && data instanceof Number && state.getCurrentValue() instanceof Long) {
+                    } else if (dataType == SlashCommandOptionType.LONG && data instanceof Number && state.getCurrentValue().get() instanceof Long) {
                         Number lData = (Number) data;
-                        long lValue = (long) state.getCurrentValue();
+                        long lValue = (Long) state.getCurrentValue().get();
 
                         if (searchType == SearchType.GREATER_THAN) {
                             return lData.longValue() > lValue;

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/type/SearchAutocomplete.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/autocomplete/type/SearchAutocomplete.java
@@ -114,7 +114,7 @@ public class SearchAutocomplete extends Autocomplete {
 
     @Override
     public List<Choice> getResult(AutocompleteState state) {
-        if (!state.getCurrentValue().isPresent() && state.getCurrentValue().toString().length() < minCharToSearch) return null;
+        if (!state.getCurrentValue().isPresent() || state.getCurrentValue().get().toString().length() < minCharToSearch) return null;
 
         Stream<Choice> choices = dataSource.stream()
                 .filter(data -> {

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/converter/ArgumentResultConverter.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/converter/ArgumentResultConverter.java
@@ -29,6 +29,6 @@ public interface ArgumentResultConverter {
      * @param value the raw value
      * @return the converted object
      */
-    public abstract Object convertTo(Object value);
+    Object convertTo(Object value);
 
 }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/converter/ArgumentResultConverter.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/converter/ArgumentResultConverter.java
@@ -23,7 +23,7 @@ package me.s3ns3iw00.jcommands.argument.converter;
  *
  * @author S3nS3IW00
  */
-public abstract class ArgumentResultConverter {
+public interface ArgumentResultConverter {
 
     /**
      * @param value the raw value

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/converter/type/URLConverter.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/converter/type/URLConverter.java
@@ -24,7 +24,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
- * Converts to {@code URL} from the given value that is expectedly is a valid {@code URL}.
+ * Converts to {@link URL} from the given value that is expectedly is a valid {@link URL}.
  *
  * @author S3nS3IW00
  */

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/converter/type/URLConverter.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/converter/type/URLConverter.java
@@ -28,7 +28,7 @@ import java.net.URL;
  *
  * @author S3nS3IW00
  */
-public class URLConverter extends ArgumentResultConverter {
+public class URLConverter implements ArgumentResultConverter {
 
     @Override
     public Object convertTo(Object value) {

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/AttachmentArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/AttachmentArgument.java
@@ -1,0 +1,85 @@
+package me.s3ns3iw00.jcommands.argument.type;
+
+import org.javacord.api.entity.Attachment;
+import org.javacord.api.interaction.SlashCommandOptionType;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An argument that only accepts attachments
+ *
+ * @author S3nS3IW00
+ */
+public class AttachmentArgument extends ValueArgument {
+
+    private final Set<String> extensions = new HashSet<>();
+    private Integer maxSize = Integer.MAX_VALUE;
+
+    public AttachmentArgument(String name, String description) {
+        super(name, description, SlashCommandOptionType.ATTACHMENT, Attachment.class);
+    }
+
+    /**
+     * Sets the valid extensions for the attachment
+     *
+     * @param validExtensions the valid extensions
+     */
+    public void setValidExtensions(String... validExtensions) {
+        extensions.addAll(Arrays.asList(validExtensions));
+    }
+
+    /**
+     * Sets the maximum allowed size for the attachment in bytes
+     *
+     * @param maxSize the max size in bytes
+     */
+    public void setMaxSize(Integer maxSize) {
+        this.maxSize = maxSize;
+    }
+
+    /**
+     * Sets the maximum allowed size for the attachment in megabytes
+     * <br>
+     * The size will be converted to bytes (multiplying by 1000 two times) and explicit converted to integer,
+     * therefore the maximum value could be 2147.483647
+     *
+     * @param maxSizeInMB the max size in megabytes
+     */
+    public void setMaxSizeInMB(Double maxSizeInMB) {
+        this.maxSize = (int) (maxSizeInMB * 1000 * 1000);
+    }
+
+    /**
+     * Validates the extension and size of the attachment
+     *
+     * @param value the value
+     * @return is the attachment valid or not
+     */
+    @Override
+    public boolean isValid(Object value) {
+        if (super.isValid(value)) {
+            Attachment attachment = (Attachment) value;
+            Optional<String> fileExtension = findExtension(attachment.getFileName());
+            return (extensions.isEmpty() || (fileExtension.isPresent() && extensions.contains(fileExtension.get()))) &&
+                    attachment.getSize() <= maxSize;
+        }
+        return false;
+    }
+
+    /**
+     * Find the extension of an attachment
+     *
+     * @param fileName the name of the attachment
+     * @return {@link Optional#empty()} when no extension found else {@link Optional#of(Object)} with the extension
+     */
+    private Optional<String> findExtension(String fileName) {
+        int lastIndex = fileName.lastIndexOf('.');
+        if (lastIndex == -1) {
+            return Optional.empty();
+        }
+        return Optional.of(fileName.substring(lastIndex + 1));
+    }
+}

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 /**
  * Represents an argument that has multiple choices, and they are the only valid values for the user to pick
  * The values are key value pairs
- * The key is {@code String} and the value can be {@code String} or {@code Long}
+ * The key is {@link String} and the value can be {@link String} or {@link Long}
  */
 public class ComboArgument extends Argument implements Optionality {
 
@@ -43,7 +43,7 @@ public class ComboArgument extends Argument implements Optionality {
      *
      * @param name        the argument's name
      * @param description the argument's description
-     * @param type        the type of the input value, can be {@code STRING} or {@code LONG}
+     * @param type        the type of the input value, can be {@link SlashCommandOptionType#STRING} or {@link SlashCommandOptionType#LONG}
      */
     public ComboArgument(String name, String description, SlashCommandOptionType type) {
         super(name, description, type);
@@ -57,7 +57,7 @@ public class ComboArgument extends Argument implements Optionality {
      * Adds a choice
      *
      * @param key   is the name of the argument
-     * @param value is the value of the argument as {@code String}
+     * @param value is the value of the argument as {@link String}
      */
     public void addChoice(String key, String value) {
         if (getType() == SlashCommandOptionType.LONG) {
@@ -71,7 +71,7 @@ public class ComboArgument extends Argument implements Optionality {
      * Adds a choice
      *
      * @param key   the name of the argument
-     * @param value the value of the argument as {@code Long}
+     * @param value the value of the argument as {@link Long}
      */
     public void addChoice(String key, long value) {
         if (getType() == SlashCommandOptionType.STRING) {

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
@@ -103,6 +103,11 @@ public class ComboArgument extends Argument implements Optionality {
         return optional;
     }
 
+    @Override
+    public void setOptional() {
+        this.optional = true;
+    }
+
     public void setOptional(boolean optional) {
         this.optional = optional;
     }

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/ComboArgument.java
@@ -25,6 +25,7 @@ import org.javacord.api.interaction.SlashCommandOption;
 import org.javacord.api.interaction.SlashCommandOptionType;
 
 import java.util.LinkedList;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -106,6 +107,11 @@ public class ComboArgument extends Argument implements Optionality {
     @Override
     public void setOptional() {
         this.optional = true;
+    }
+
+    @Override
+    public Optional<?> getOptionalValue() {
+        return Optional.ofNullable(choice);
     }
 
     public void setOptional(boolean optional) {

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/type/GroupArgument.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/type/GroupArgument.java
@@ -27,8 +27,8 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 /**
- * Represents an argument with {@code SUB_COMMAND_GROUP} type that only can contain {@link ConstantArgument}
- * This is for grouping {@code SUB_COMMAND} options because {@code SUB_COMMANDS} cannot be nested
+ * Represents an argument with {@link SlashCommandOptionType#SUB_COMMAND_GROUP} type that only can contain {@link ConstantArgument}
+ * This is for grouping {@link SlashCommandOptionType#SUB_COMMAND} options because {@link SlashCommandOptionType#SUB_COMMAND} cannot be nested
  */
 public class GroupArgument extends SubArgument<ConstantArgument> {
 

--- a/src/main/java/me/s3ns3iw00/jcommands/argument/util/Choice.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/argument/util/Choice.java
@@ -54,6 +54,22 @@ public class Choice {
         return value;
     }
 
+    public String getValueAsString() {
+        if (!(value instanceof String)) {
+            throw new IllegalStateException("The value is not a String, but a Long! Use getValueAsLong()");
+        }
+
+        return (String) value;
+    }
+
+    public Long getValueAsLong() {
+        if (!(value instanceof Long)) {
+            throw new IllegalStateException("The value is not a Long, but a String! Use getValueAsString()");
+        }
+
+        return (Long) value;
+    }
+
     /**
      * Constructs the {@link SlashCommandOptionChoice} instance
      *

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/CommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/CommandBuilder.java
@@ -27,7 +27,7 @@ import org.javacord.api.entity.permission.PermissionType;
 import java.util.Arrays;
 
 /**
- * Useful class that makes {@code Command} creations more comfortable
+ * Useful class that makes {@link Command} creations more comfortable
  *
  * @param <B> the type of the builder
  * @author S3nS3IW00

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/CommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/CommandBuilder.java
@@ -22,6 +22,7 @@ import me.s3ns3iw00.jcommands.Command;
 import me.s3ns3iw00.jcommands.argument.Argument;
 import me.s3ns3iw00.jcommands.argument.concatenation.Concatenator;
 import me.s3ns3iw00.jcommands.event.listener.CommandActionEventListener;
+import org.javacord.api.entity.permission.PermissionType;
 
 import java.util.Arrays;
 
@@ -61,6 +62,17 @@ public abstract class CommandBuilder<B extends CommandBuilder<B>> {
      */
     public B onAction(CommandActionEventListener listener) {
         getCommand().setOnAction(listener);
+        return (B) this;
+    }
+
+    /**
+     * Calls {@link Command#addPermissions(PermissionType...)}
+     *
+     * @param permissionTypes the permissions
+     * @return this class
+     */
+    public B permissions(PermissionType... permissionTypes) {
+        getCommand().addPermissions(permissionTypes);
         return (B) this;
     }
 

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/SlashCommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/SlashCommandBuilder.java
@@ -33,7 +33,9 @@ import java.util.Arrays;
  * Useful class that makes {@code ServerCommand} creations more comfortable
  *
  * @author S3nS3IW00
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class SlashCommandBuilder extends CommandBuilder<SlashCommandBuilder> {
 
     private final SlashCommand command;

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/type/GlobalCommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/type/GlobalCommandBuilder.java
@@ -1,0 +1,33 @@
+package me.s3ns3iw00.jcommands.builder.type;
+
+import me.s3ns3iw00.jcommands.Command;
+import me.s3ns3iw00.jcommands.builder.CommandBuilder;
+import me.s3ns3iw00.jcommands.type.GlobalCommand;
+
+/**
+ * Useful class that makes {@link GlobalCommand} creations more comfortable
+ */
+public class GlobalCommandBuilder extends CommandBuilder<GlobalCommandBuilder> {
+
+    private final GlobalCommand command;
+
+    public GlobalCommandBuilder(String name, String description) {
+        command = new GlobalCommand(name, description);
+    }
+
+    public GlobalCommandBuilder enableInDMs() {
+        command.enableInDMs();
+        return this;
+    }
+
+    public GlobalCommandBuilder disableInDMs() {
+        command.disableInDMs();
+        return this;
+    }
+
+    @Override
+    public Command getCommand() {
+        return command;
+    }
+
+}

--- a/src/main/java/me/s3ns3iw00/jcommands/builder/type/ServerCommandBuilder.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/builder/type/ServerCommandBuilder.java
@@ -1,0 +1,23 @@
+package me.s3ns3iw00.jcommands.builder.type;
+
+import me.s3ns3iw00.jcommands.Command;
+import me.s3ns3iw00.jcommands.builder.CommandBuilder;
+import me.s3ns3iw00.jcommands.type.ServerCommand;
+
+/**
+ * Useful class that makes {@link ServerCommand} creations more comfortable
+ */
+public class ServerCommandBuilder extends CommandBuilder<ServerCommandBuilder> {
+
+    private final ServerCommand command;
+
+    public ServerCommandBuilder(String name, String description) {
+        command = new ServerCommand(name, description);
+    }
+
+    @Override
+    public Command getCommand() {
+        return command;
+    }
+
+}

--- a/src/main/java/me/s3ns3iw00/jcommands/event/listener/BadCategoryEventListener.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/event/listener/BadCategoryEventListener.java
@@ -22,7 +22,10 @@ import me.s3ns3iw00.jcommands.event.type.BadCategoryEvent;
 
 /**
  * A listener that gets triggered when a {@link me.s3ns3iw00.jcommands.limitation.type.CategoryLimitable} command used in wrong category
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface BadCategoryEventListener {
 
     void onBadCategory(BadCategoryEvent event);

--- a/src/main/java/me/s3ns3iw00/jcommands/event/listener/BadChannelEventListener.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/event/listener/BadChannelEventListener.java
@@ -22,7 +22,10 @@ import me.s3ns3iw00.jcommands.event.type.BadChannelEvent;
 
 /**
  * A listener that gets triggered when a {@link me.s3ns3iw00.jcommands.limitation.type.ChannelLimitable} command used in wrong channel
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface BadChannelEventListener {
 
     void onBadChannel(BadChannelEvent event);

--- a/src/main/java/me/s3ns3iw00/jcommands/event/type/BadCategoryEvent.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/event/type/BadCategoryEvent.java
@@ -28,7 +28,10 @@ import org.javacord.api.entity.user.User;
  * An event that is provided by {@link me.s3ns3iw00.jcommands.event.listener.BadCategoryEventListener}
  * <p>
  * Contains the {@link ChannelCategory} where the command was used
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class BadCategoryEvent extends CommandEvent {
 
     private final ChannelCategory category;

--- a/src/main/java/me/s3ns3iw00/jcommands/event/type/BadChannelEvent.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/event/type/BadChannelEvent.java
@@ -28,7 +28,10 @@ import org.javacord.api.entity.user.User;
  * An event that is provided by {@link me.s3ns3iw00.jcommands.event.listener.BadChannelEventListener}
  * <p>
  * Contains the {@link TextChannel} where the command was used
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class BadChannelEvent extends CommandEvent {
 
     private final TextChannel channel;

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/Limitation.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/Limitation.java
@@ -24,7 +24,9 @@ import org.javacord.api.entity.server.Server;
  * Represents a command limitation
  *
  * @param <T> aspect that the command will be limited by
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public abstract class Limitation<T> {
 
     /**

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
@@ -25,7 +25,10 @@ import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for categories
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface CategoryLimitable {
 
     default void addCategoryLimitation(CategoryLimitation limitation) {

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitable.java
@@ -28,7 +28,9 @@ import java.util.Set;
  */
 public interface CategoryLimitable {
 
-    void addCategoryLimitation(CategoryLimitation limitation);
+    default void addCategoryLimitation(CategoryLimitation limitation) {
+        getCategoryLimitations().add(limitation);
+    }
 
     Set<CategoryLimitation> getCategoryLimitations();
 

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitation.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/CategoryLimitation.java
@@ -24,7 +24,10 @@ import org.javacord.api.entity.server.Server;
 
 /**
  * Represents a specific type of limitation
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class CategoryLimitation extends Limitation<ChannelCategory> {
 
     private final ChannelCategory entity;

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
@@ -25,7 +25,10 @@ import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for channels
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface ChannelLimitable {
 
     default void addChannelLimitation(ChannelLimitation limitation) {

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitable.java
@@ -28,7 +28,9 @@ import java.util.Set;
  */
 public interface ChannelLimitable {
 
-    void addChannelLimitation(ChannelLimitation limitation);
+    default void addChannelLimitation(ChannelLimitation limitation) {
+        getChannelLimitations().add(limitation);
+    }
 
     Set<ChannelLimitation> getChannelLimitations();
 

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitation.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/ChannelLimitation.java
@@ -24,7 +24,10 @@ import org.javacord.api.entity.server.Server;
 
 /**
  * Represents a specific type of limitation
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class ChannelLimitation extends Limitation<TextChannel> {
 
     private final TextChannel entity;

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
@@ -22,7 +22,10 @@ import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for roles
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface RoleLimitable {
 
     default void addRoleLimitation(RoleLimitation limitation) {

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitable.java
@@ -25,7 +25,9 @@ import java.util.Set;
  */
 public interface RoleLimitable {
 
-    void addRoleLimitation(RoleLimitation limitation);
+    default void addRoleLimitation(RoleLimitation limitation) {
+        getRoleLimitations().add(limitation);
+    }
 
     Set<RoleLimitation> getRoleLimitations();
 

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitation.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/RoleLimitation.java
@@ -25,7 +25,10 @@ import org.javacord.api.entity.server.Server;
 /**
  * Represents a specific type of limitation
  * Commands with this limitation do not work in private
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class RoleLimitation extends Limitation<Role> {
 
     private final Role entity;

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
@@ -22,7 +22,10 @@ import java.util.Set;
 
 /**
  * Commands that implements this interface can be limited for users
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public interface UserLimitable {
 
     default void addUserLimitation(UserLimitation limitation) {

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitable.java
@@ -25,7 +25,9 @@ import java.util.Set;
  */
 public interface UserLimitable {
 
-    void addUserLimitation(UserLimitation limitation);
+    default void addUserLimitation(UserLimitation limitation) {
+        getUserLimitations().add(limitation);
+    }
 
     Set<UserLimitation> getUserLimitations();
 

--- a/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitation.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/limitation/type/UserLimitation.java
@@ -25,7 +25,10 @@ import org.javacord.api.entity.user.User;
 /**
  * Represents a specific type of limitation
  * Commands with this limitation do not work in private
+ *
+ * @deprecated because of the new permission system
  */
+@Deprecated
 public class UserLimitation extends Limitation<User> {
 
     private final User entity;

--- a/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
@@ -3,7 +3,7 @@ package me.s3ns3iw00.jcommands.type;
 import me.s3ns3iw00.jcommands.Command;
 
 /**
- * A {@link Command} that will be registered on all the servers where the bot on
+ * A {@link Command} that will be registered on all the servers where the bot on and also can be available in dms
  */
 public class GlobalCommand extends Command {
 
@@ -42,7 +42,7 @@ public class GlobalCommand extends Command {
     /**
      * Checks if the command is enabled in DMs
      *
-     * @return {@code true} if the command is enabled in DMs, {@code false} otherwise
+     * @return true if the command is enabled in DMs, false otherwise
      */
     public boolean isEnabledInDMs() {
         return enabledInDMs;

--- a/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 S3nS3IW00
+ *
+ * This file is part of JCommands.
+ *
+ * JCommands is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser general Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * JCommands is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
 package me.s3ns3iw00.jcommands.type;
 
 import me.s3ns3iw00.jcommands.Command;

--- a/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/GlobalCommand.java
@@ -1,0 +1,50 @@
+package me.s3ns3iw00.jcommands.type;
+
+import me.s3ns3iw00.jcommands.Command;
+
+/**
+ * A {@link Command} that will be registered on all the servers where the bot on
+ */
+public class GlobalCommand extends Command {
+
+    private boolean enabledInDMs = true;
+
+    /**
+     * Default constructor
+     *
+     * @param name        the name of the command
+     *                    Its length must between 1 and 32
+     *                    Can contain only:
+     *                    - word characters
+     *                    - numbers
+     *                    - '-' characters
+     * @param description the description of the command
+     *                    Its length must between 1 and 100
+     */
+    public GlobalCommand(String name, String description) {
+        super(name, description);
+    }
+
+    /**
+     * Disables the command in DMs
+     */
+    public void disableInDMs() {
+        enabledInDMs = false;
+    }
+
+    /**
+     * Enables the command in DMs
+     */
+    public void enableInDMs() {
+        enabledInDMs = true;
+    }
+
+    /**
+     * Checks if the command is enabled in DMs
+     *
+     * @return {@code true} if the command is enabled in DMs, {@code false} otherwise
+     */
+    public boolean isEnabledInDMs() {
+        return enabledInDMs;
+    }
+}

--- a/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
@@ -1,0 +1,26 @@
+package me.s3ns3iw00.jcommands.type;
+
+import me.s3ns3iw00.jcommands.Command;
+
+/**
+ * A {@link Command} that only can be registered on servers
+ */
+public class ServerCommand extends Command {
+
+    /**
+     * Default constructor
+     *
+     * @param name        the name of the command
+     *                    Its length must between 1 and 32
+     *                    Can contain only:
+     *                    - word characters
+     *                    - numbers
+     *                    - '-' characters
+     * @param description the description of the command
+     *                    Its length must between 1 and 100
+     */
+    public ServerCommand(String name, String description) {
+        super(name, description);
+    }
+
+}

--- a/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/ServerCommand.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2022 S3nS3IW00
+ *
+ * This file is part of JCommands.
+ *
+ * JCommands is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser general Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * JCommands is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, see <http://www.gnu.org/licenses/>.
+ */
 package me.s3ns3iw00.jcommands.type;
 
 import me.s3ns3iw00.jcommands.Command;

--- a/src/main/java/me/s3ns3iw00/jcommands/type/SlashCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/SlashCommand.java
@@ -30,7 +30,11 @@ import java.util.Set;
 /**
  * A {@code Command} that only can be used on servers where the command has been registered.<br>
  * Can be limited for users, roles, channels and categories.
+ *
+ * @deprecated This class is deprecated and will be removed in the future.
+ *             Use {@link Command} class's implementations instead.
  */
+@Deprecated
 public class SlashCommand extends Command implements UserLimitable, RoleLimitable, ChannelLimitable, CategoryLimitable {
 
     private final Set<UserLimitation> userLimitations = new HashSet<>();

--- a/src/main/java/me/s3ns3iw00/jcommands/type/SlashCommand.java
+++ b/src/main/java/me/s3ns3iw00/jcommands/type/SlashCommand.java
@@ -46,18 +46,8 @@ public class SlashCommand extends Command implements UserLimitable, RoleLimitabl
     }
 
     @Override
-    public void addCategoryLimitation(CategoryLimitation limitation) {
-        categoryLimitations.add(limitation);
-    }
-
-    @Override
     public Set<CategoryLimitation> getCategoryLimitations() {
         return categoryLimitations;
-    }
-
-    @Override
-    public void addChannelLimitation(ChannelLimitation limitation) {
-        channelLimitations.add(limitation);
     }
 
     @Override
@@ -66,18 +56,8 @@ public class SlashCommand extends Command implements UserLimitable, RoleLimitabl
     }
 
     @Override
-    public void addRoleLimitation(RoleLimitation limitation) {
-        roleLimitations.add(limitation);
-    }
-
-    @Override
     public Set<RoleLimitation> getRoleLimitations() {
         return roleLimitations;
-    }
-
-    @Override
-    public void addUserLimitation(UserLimitation limitation) {
-        userLimitations.add(limitation);
     }
 
     @Override

--- a/src/test/java/me/s3ns3iw00/jcommands/TestMain.java
+++ b/src/test/java/me/s3ns3iw00/jcommands/TestMain.java
@@ -3,20 +3,19 @@ package me.s3ns3iw00.jcommands;
 import me.s3ns3iw00.jcommands.argument.ArgumentResult;
 import me.s3ns3iw00.jcommands.argument.type.*;
 import me.s3ns3iw00.jcommands.argument.util.Choice;
-import me.s3ns3iw00.jcommands.limitation.type.CategoryLimitation;
-import me.s3ns3iw00.jcommands.limitation.type.ChannelLimitation;
-import me.s3ns3iw00.jcommands.limitation.type.RoleLimitation;
-import me.s3ns3iw00.jcommands.type.SlashCommand;
+import me.s3ns3iw00.jcommands.type.ServerCommand;
 import org.javacord.api.DiscordApi;
 import org.javacord.api.DiscordApiBuilder;
+import org.javacord.api.entity.Attachment;
 import org.javacord.api.entity.channel.Channel;
+import org.javacord.api.entity.channel.ChannelType;
 import org.javacord.api.entity.message.MessageBuilder;
+import org.javacord.api.entity.message.MessageFlag;
 import org.javacord.api.entity.server.Server;
 import org.javacord.api.entity.user.User;
 import org.javacord.api.interaction.SlashCommandOptionType;
-import org.javacord.api.interaction.callback.InteractionCallbackDataFlag;
 
-import java.net.URL;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 public class TestMain {
@@ -34,20 +33,10 @@ public class TestMain {
 
         // Creating instance of the servers where the bot on
         // -- DON'T FORGET TO REPLACE THIS WITH YOUR SERVER ID --
-        Server myServer = api.getServerById(787364551598407700L).get();
-
-        // Creating a command
-        // -- DON'T FORGET TO REPLACE CATEGORY, CHANNEL AND ROLE IDs WITH YOURS --
+        Server myServer = api.getServerById(787364551598407700L).orElse(null);
 
         // Create a command with a name and a description
-        SlashCommand introduceCommand = new SlashCommand("iam", "This command is for to introduce yourself.");
-        // We want to make this command available in only one category
-        introduceCommand.addCategoryLimitation(CategoryLimitation.with(myServer, true, api.getChannelCategoryById(787365901552451595L).get()));
-        // But we have two channels in that category where the command should not to work
-        introduceCommand.addChannelLimitation(ChannelLimitation.with(myServer, false, api.getTextChannelById(787366035207618573L).get()));
-        introduceCommand.addChannelLimitation(ChannelLimitation.with(myServer, false, api.getTextChannelById(787366059643502644L).get()));
-        // This command is only for users who have this role
-        introduceCommand.addRoleLimitation(RoleLimitation.with(myServer, true, api.getRoleById(787366309561368606L).get()));
+        ServerCommand introduceCommand = new ServerCommand("iam", "This command is for to introduce yourself.");
         // Let's create our command's first argument.
         ValueArgument nameArgument = new ValueArgument("fullname", "Your first and last name separated with comma (Firstname,Lastname)", SlashCommandOptionType.STRING);
         // This argument only accepts two word separated with comma and each word started with capitalized letter.
@@ -57,7 +46,7 @@ public class TestMain {
         nameArgument.setOnMismatch(event -> {
             event.getResponder().respondNow()
                     .setContent("The name is not valid for the pattern. :face_with_raised_eyebrow:")
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
+                    .setFlags(MessageFlag.EPHEMERAL)
                     .respond();
         });
         // We want to know the user's gender so make an argument that has two acceptable values.
@@ -71,7 +60,7 @@ public class TestMain {
         ageArgument.setOnMismatch(event -> {
             event.getResponder().respondNow()
                     .setContent("The age must between 0 and 99. :face_with_raised_eyebrow:")
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
+                    .setFlags(MessageFlag.EPHEMERAL)
                     .respond();
         });
         // Let's ask the user to mention his or her best friend,
@@ -79,31 +68,18 @@ public class TestMain {
         // to mention his or her favourite channel on this server
         ChannelArgument favouriteChannelArgument = new ChannelArgument("favouritechannel", "Your favourite channel on this server");
         // and to send us a funny picture's url, that is just an optional argument
-        URLArgument funnyPictureArgument = new URLArgument("funnypicture", "A funny picture's url");
+        AttachmentArgument funnyPictureArgument = new AttachmentArgument("funnypicture", "A funny picture (png or jpg)");
+        funnyPictureArgument.setValidExtensions("png", "jpg");
         funnyPictureArgument.setOptional();
-        // URL is not built-in argument type, so the user can give text that is not a valid url, so we need to send an error message to the user
+        // Since the extension is limited for the attachment, the user has to be informed about that the attachment is invalid
         funnyPictureArgument.setOnMismatch(event -> {
             event.getResponder().respondNow()
-                    .setContent("The given URL is not a valid URL. :face_with_raised_eyebrow:")
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
+                    .setContent("The uploaded attachment is not valid! The only acceptable extensions are `png` and `jpg` :face_with_raised_eyebrow:")
+                    .setFlags(MessageFlag.EPHEMERAL)
                     .respond();
         });
         // Add arguments to the command
         introduceCommand.addArgument(nameArgument, genderArgument, ageArgument, bestFriendArgument, favouriteChannelArgument, funnyPictureArgument);
-        // Handle event that gets triggered when the command is used in a category where it is not allowed
-        introduceCommand.setOnBadCategory(event -> {
-            event.getResponder().respondNow()
-                    .setContent("This command cannot be used in this category. :face_with_raised_eyebrow:")
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
-                    .respond();
-        });
-        // Handle event that gets triggered when the command is used in a channel where it is not allowed
-        introduceCommand.setOnBadChannel(event -> {
-            event.getResponder().respondNow()
-                    .setContent("This command cannot be used in this channel. :face_with_raised_eyebrow:")
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
-                    .respond();
-        });
         // Let's make an action listener where we can listen for inputs.
         introduceCommand.setOnAction(event -> {
             // Get the arguments from the event
@@ -124,28 +100,25 @@ public class TestMain {
             User bestFriend = args[3].get();
             Channel favouriteChannel = args[4].get();
 
-            // URL arguments are also getting converted into the corresponding type
-            // This is an optional argument, so we need to check that this have been specified
-            URL funnyPictureUrl = args.length < 6 ? null : args[5].get();
+            // This is an optional argument, so its result is stored in an Optional
+            Optional<Attachment> funnyPicture = args[5].get();
 
             // Something that uses all the arguments
             MessageBuilder responseMessage = new MessageBuilder();
-            responseMessage.append("Hi " + firstName + " " + lastName + "! You are very " + ((long) gender.getValue() == 0 ? "handsome" : "beautiful") + " :heart: As I can see you are " + (age >= 10 && age < 20 ? "" : "not ") + "a teenager.");
+            responseMessage.append("Hi " + firstName + " " + lastName + "! You are very " + (gender.getValueAsLong() == 0 ? "handsome" : "beautiful") + " :heart: As I can see you are " + (age >= 10 && age < 20 ? "" : "not ") + "a teenager.");
             if (bestFriend.isBot()) {
                 responseMessage.append(" What? Did you know that your best friend is a BOT?");
             }
-            if (favouriteChannel.getId() == 791658134153330718L) {
-                responseMessage.append(" That's my favourite channel too!");
+            if (favouriteChannel.getType() == ChannelType.SERVER_VOICE_CHANNEL) {
+                responseMessage.append(" I like voice channels too!");
             }
-            if (funnyPictureUrl != null) {
-                responseMessage.append(" Here is your funny picture: " + funnyPictureUrl);
-            }
+            funnyPicture.ifPresent(attachment -> responseMessage.append(" Here is your funny picture: ").append(responseMessage.append(attachment.getUrl())));
 
             // Send the response message to the user with the responder from the event
             // EPHEMERAL flag means that the response will only be visible for the user
             event.getResponder().respondNow()
                     .setContent(responseMessage.getStringBuilder().toString())
-                    .setFlags(InteractionCallbackDataFlag.EPHEMERAL)
+                    .setFlags(MessageFlag.EPHEMERAL)
                     .respond();
         });
         // And don't forget to register the command on the server(s). (I always forget it and never know what's wrong :D)

--- a/src/test/java/me/s3ns3iw00/jcommands/person/converter/DateConverter.java
+++ b/src/test/java/me/s3ns3iw00/jcommands/person/converter/DateConverter.java
@@ -8,7 +8,7 @@ import java.text.SimpleDateFormat;
 /**
  * An {@link ArgumentResultConverter} that converts {@link String} value formatted by {@link DateConverter#DATE_FORMAT} into {@link java.util.Date}
  */
-public class DateConverter extends ArgumentResultConverter {
+public class DateConverter implements ArgumentResultConverter {
 
     // The date format
     public static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");

--- a/src/test/java/me/s3ns3iw00/jcommands/person/converter/DateConverter.java
+++ b/src/test/java/me/s3ns3iw00/jcommands/person/converter/DateConverter.java
@@ -6,7 +6,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
 /**
- * An {@link ArgumentResultConverter} that converts {@link String} value formatted by {@code DATE_FORMAT} into {@link java.util.Date}
+ * An {@link ArgumentResultConverter} that converts {@link String} value formatted by {@link DateConverter#DATE_FORMAT} into {@link java.util.Date}
  */
 public class DateConverter extends ArgumentResultConverter {
 


### PR DESCRIPTION
# Changelog
- SlashCommand, SlashCommandBuilder, and old permission system marked as deprecated
- Modal respond added to CommandResponder
- Implemented Discord's new permission system
- Added ServerCommand and GlobalCommand as default commands
    - Command's initial permissions can be set
    - GlobalCommand can be enabled in DMs
    - New builders
- Ephemeral added to late response
- Added support for Attachment arguments (AttachmentArgument)
    - Size and file extension can be limited
- Return optional arguments as an Optional in the action listener